### PR TITLE
Update express.js

### DIFF
--- a/express.js
+++ b/express.js
@@ -6,6 +6,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     var revision = req.params.rev ? req.params.rev : null;
 
     exportMarkdown.getPadMarkdownDocument(padID, revision, function(err, result) {
+      res.header('Access-Control-Allow-Origin', '*');
       res.contentType('plain/text');
       res.send(result);
     });


### PR DESCRIPTION
Adding Access-Control-Allow-Origin header to prevent Access to XMLHttpRequest at 'https://host:port/p/pad/export/markdown' from origin 'https://otherhost' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.