### PR TITLE
add CORS headers to allow use of etherpad API inside browsers

### DIFF
--- a/express.js
+++ b/express.js
@@ -8,6 +8,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     exportMarkdown.getPadMarkdownDocument(padID, revision, function(err, result) {
       res.setHeader('Content-disposition', 'attachment; filename='+padID+'.md');
       res.contentType('plain/text');
+      res.header('Access-Control-Allow-Origin', '*');
       res.send(result);
     });
   });


### PR DESCRIPTION
This pull request add CORS headers to allow use of etherpad API inside browsers.

However, I'm not sure this pull request is the best answer to the problem that we try to fix.

If we try to open the etherpad API inside browsers, the fix should not be specific to one plugin, it should be a global etherpad configuration flag to enable or not the API, and to enable or not the CORS header (and to which domains).

As I need CORS headers for the `ep_markdown` plugin, this pull request appears to be a small workaround for my usecase. But does not address the general usecase of allowing the use of etherpad API inside the browser.

This has been discussed in another issue : [Suggesting new HTTP API](https://github.com/ether/etherpad-lite/issues/669#issuecomment-5305744).