### PR TITLE
Fix hook function returns

### DIFF
--- a/express.js
+++ b/express.js
@@ -11,4 +11,5 @@ exports.expressCreateServer = function (hook_name, args, cb) {
       res.send(result);
     });
   });
+  return cb();
 };


### PR DESCRIPTION
Hook functions must either return a non-undefined value or call the callback, and they must not do both.