### PR TITLE
the caller of exports.getPadMarkdown define revNum to be `null` in case it's not given

### DIFF
--- a/exportMarkdown.js
+++ b/exportMarkdown.js
@@ -12,7 +12,7 @@ exports.getPadMarkdown = (pad, revNum, callback) => {
 
     // fetch revision atext
     (callback) => {
-      if (revNum !== undefined) {
+      if (revNum !== null) {
         pad.getInternalRevisionAText(revNum, (err, revisionAtext) => {
           if (ERR(err, callback)) return;
           atext = revisionAtext;

--- a/exportMarkdown.js
+++ b/exportMarkdown.js
@@ -12,7 +12,7 @@ exports.getPadMarkdown = (pad, revNum, callback) => {
 
     // fetch revision atext
     (callback) => {
-      if (revNum !== null) {
+      if (revNum != null) {
         pad.getInternalRevisionAText(revNum, (err, revisionAtext) => {
           if (ERR(err, callback)) return;
           atext = revisionAtext;


### PR DESCRIPTION
don't know ep_markdown well, so in case that function is used from other callers it probably should also check for `undefined`

made the backend tests hang for hours on core :-)