### PR TITLE
Fix broken export link if URL does not contain /p/

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -5,7 +5,6 @@
       "hooks":{
         "expressCreateServer": "ep_markdown/express",
         "eejsBlock_exportColumn": "ep_markdown/index",
-        "eejsBlock_scripts": "ep_markdown/index",
         "eejsBlock_mySettings": "ep_markdown/index",
         "import": "ep_markdown/index"
       },

--- a/index.js
+++ b/index.js
@@ -9,10 +9,6 @@ exports.eejsBlock_exportColumn = (hookName, context) => {
   context.content += eejs.require('./templates/exportcolumn.html', {}, module);
 };
 
-exports.eejsBlock_scripts = (hookName, context) => {
-  context.content += eejs.require('./templates/scripts.html', {}, module);
-};
-
 exports.eejsBlock_styles = (hookName, context) => {
   context.content += eejs.require('./templates/styles.html', {}, module);
 };

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,7 +1,0 @@
-'use strict';
-
-$(document).ready(() => {
-  const padRootPath = new RegExp(/.*\/p\/[^/]+/)
-      .exec(document.location.pathname) || clientVars.padId;
-  $('#exportmarkdowna').attr('href', `${padRootPath}/export/markdown`);
-});

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -1,6 +1,10 @@
 'use strict';
 
 exports.postAceInit = (hookName, context) => {
+  const padRootPath = new RegExp(/.*\/p\/[^/]+/)
+      .exec(document.location.pathname) || clientVars.padId;
+  $('#exportmarkdowna').attr('href', `${padRootPath}/export/markdown`);
+
   const enable = () => {
     // add css class markdown
     $('iframe[name="ace_outer"]').contents().find('iframe')

--- a/templates/scripts.html
+++ b/templates/scripts.html
@@ -1,1 +1,0 @@
-<script src="../static/plugins/ep_markdown/static/js/main.js"></script>


### PR DESCRIPTION
Fixes #118

Fallback with clientVars.padId does not work at this point, because clientVars is not populated with padId at document.ready state.