### PR TITLE
Added support for the importExportRateLimiting setting, and Access-Control-Allow-Origin header added. Fixed the export of readonly pads.

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,12 +1,27 @@
 'use strict';
 
 const exportMarkdown = require('./exportMarkdown');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+const rateLimit = require('express-rate-limit');
 
 exports.expressCreateServer = (hookName, {app}) => {
+  const limiter = rateLimit({
+    ...settings.importExportRateLimiting,
+    handler: (request) => {
+      if (request.rateLimit.current === request.rateLimit.limit + 1) {
+        // when the rate limiter triggers, write a warning in the logs
+        console.warn('Import/Export rate limiter triggered on ' +
+            `"${request.originalUrl}" for IP address ${request.ip}`);
+      }
+    },
+  });
+  
+  app.use('/p/:padId/:revNum?/export/markdown', limiter);
   app.get('/p/:padId/:revNum?/export/markdown', (req, res, next) => {
     (async () => {
       const {padId, revNum} = req.params;
       res.attachment(`${padId}.md`);
+      res.header('Access-Control-Allow-Origin', '*');
       res.contentType('plain/text');
       res.send(await exportMarkdown.getPadMarkdownDocument(padId, revNum));
     })().catch((err) => next(err || new Error(err)));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/ether/ep_markdown.git"
   },
   "dependencies": {
+    "express-rate-limit": "^7.2.0",
     "showdown": "*"
   },
   "contributors": [],


### PR DESCRIPTION
As mentioned several times (#9, #30, #139), in order to use ep_markdown through the Etherpad API, we need to add the CORS headers to the request. The problem with only doing that, if I understood well, is that it exposes the server to DDOS attacks.

In order to circumvent the problem, the other import/export functionalities of Etherpad are capped through a variable set in the `settings.json` file: `importExportRateLimiting`. The implementation of this setting is done in [the `importexport.ts` file of etherpad-lite](https://github.com/ether/etherpad-lite/blob/40116a322170e9355cb5b5c7ba530b63fb5718be/src/node/hooks/express/importexport.ts#L15).

This PR aims at implementing this limiter alongside the CORS headers, in order to be able to use the export function of ep_markdown through the API.