### PR TITLE
feat: migrate to ep_plugin_helpers padToggle for User + Pad Wide settings

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,13 +4,17 @@
       "name": "markdown",
       "hooks":{
         "expressCreateServer": "ep_markdown/express",
+        "loadSettings": "ep_markdown/index",
+        "clientVars": "ep_markdown/index",
         "eejsBlock_exportColumn": "ep_markdown/index",
         "eejsBlock_mySettings": "ep_markdown/index",
+        "eejsBlock_padSettings": "ep_markdown/index",
         "import": "ep_markdown/index"
       },
       "client_hooks": {
         "aceEditorCSS": "ep_markdown/static/js/markdown",
-        "postAceInit": "ep_markdown/static/js/markdown"
+        "postAceInit": "ep_markdown/static/js/markdown",
+        "handleClientMessage_CLIENT_MESSAGE": "ep_markdown/static/js/markdown:handleClientMessage_CLIENT_MESSAGE"
       }
     }
   ]

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,24 @@
 'use strict';
 
 const eejs = require('ep_etherpad-lite/node/eejs');
-import settings from 'ep_etherpad-lite/node/utils/Settings';
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 import {promises} from 'fs';
 const fsp = promises
+
+// Parallel User Settings + Pad Wide Settings checkboxes for "Show Markdown".
+// Helper owns storage, broadcast, enforce, and i18n wiring.
+const markdownToggle = padToggle({
+  pluginName: 'ep_markdown',
+  settingId: 'markdown',
+  l10nId: 'ep_markdown.showMarkdown',
+  defaultLabel: 'Show Markdown',
+  defaultEnabled: false,
+});
+
+exports.loadSettings = markdownToggle.loadSettings;
+exports.clientVars = markdownToggle.clientVars;
+exports.eejsBlock_mySettings = markdownToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = markdownToggle.eejsBlock_padSettings;
 
 exports.eejsBlock_exportColumn = (hookName, context) => {
   context.content += eejs.require('./templates/exportcolumn.html', {}, module);
@@ -11,17 +26,6 @@ exports.eejsBlock_exportColumn = (hookName, context) => {
 
 exports.eejsBlock_styles = (hookName, context) => {
   context.content += eejs.require('./templates/styles.html', {}, module);
-};
-
-exports.eejsBlock_mySettings = (hookName, context) => {
-  let checkedState = 'unchecked';
-  if (!settings.ep_markdown_default) {
-    checkedState = 'unchecked';
-  } else if (settings.ep_markdown_default === true) {
-    checkedState = 'checked';
-  }
-  context.content +=
-      eejs.require('./templates/markdown_entry.ejs', {checked: checkedState}, module);
 };
 
 exports.import = async (hookName, {destFile, fileEnding, srcFile}) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_markdown",
   "description": "Edit and Export as Markdown in Etherpad",
-  "version": "11.0.20",
+  "version": "12.0.0",
   "author": {
     "name": "John McLear",
     "email": "john@mclear.co.uk",
@@ -12,6 +12,7 @@
     "url": "https://github.com/ether/ep_markdown.git"
   },
   "dependencies": {
+    "ep_plugin_helpers": "^0.3.0",
     "showdown": "^2.1.0"
   },
   "contributors": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.3.0
+        version: 0.3.1
       showdown:
         specifier: ^2.1.0
         version: 2.1.0
@@ -419,6 +422,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.3.1:
+    resolution: {integrity: sha512-PHvLsJGJHQNLvP4R4k+D54f6JasD/uv9T4S0UaLHePjQBy0INpiS8iFXLeAY60EbgeznhMJLgE2DVy+32bZTLQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1707,6 +1714,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.3.1: {}
 
   es-abstract@1.24.2:
     dependencies:

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -1,5 +1,26 @@
 'use strict';
 
+// Sub-path import keeps the client bundle clean. Importing the top-level
+// `ep_plugin_helpers` index pulls in every helper's getters; `settings` and
+// `toggle` reach server-only modules (eejs, Settings) which esbuild can't
+// resolve for the browser.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel for the checkbox ids and clientVars
+// lookup to line up.
+const markdownToggle = padToggle({
+  pluginName: 'ep_markdown',
+  settingId: 'markdown',
+  l10nId: 'ep_markdown.showMarkdown',
+  defaultLabel: 'Show Markdown',
+  defaultEnabled: false,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = markdownToggle.handleClientMessage_CLIENT_MESSAGE;
+
 exports.postAceInit = (hookName, context) => {
   const padRootPath = new RegExp(/.*\/p\/[^/]+/)
       .exec(document.location.pathname) || clientVars.padId;
@@ -20,19 +41,8 @@ exports.postAceInit = (hookName, context) => {
     $('#strikethrough').removeAttr('style');
   };
 
-  /* init */
-  if ($('#options-markdown').is(':checked')) {
-    enable();
-  } else {
-    disable();
-  }
-  /* on click */
-  $('#options-markdown').on('click', () => {
-    if ($('#options-markdown').is(':checked')) {
-      enable();
-    } else {
-      disable();
-    }
+  markdownToggle.init({
+    onChange: (enabled) => { enabled ? enable() : disable(); },
   });
 };
 

--- a/templates/markdown_entry.ejs
+++ b/templates/markdown_entry.ejs
@@ -1,4 +1,0 @@
-<p>
-  <input type="checkbox" id="options-markdown" <%= checked %>></input> 
-  <label for="options-markdown" data-l10n-id="ep_markdown.showMarkdown">Show markdown</label>
-</p>


### PR DESCRIPTION
## Summary

- Migrate "Show Markdown" from a hand-rolled User-Settings-only checkbox to `padToggle` from `ep_plugin_helpers` ^0.3.0, which renders parallel checkboxes in **both** the User Settings and Pad Wide Settings panels and rides Etherpad's native `padoptions` broadcast/persist rail.
- Helper now owns checkbox rendering, cookie persistence, COLLABROOM broadcast, `enforceSettings`, and i18n. The hand-rolled `markdown_entry.ejs` template, manual `$('#options-markdown').on('click')` wiring, and the `settings.ep_markdown_default` admin key are gone.
- Admins can still default the toggle via `settings.json` `ep_markdown.defaultEnabled = true` (the helper's standard config convention).
- Sub-path imports used to keep the client bundle clean: server uses `ep_plugin_helpers/pad-toggle-server`, client uses `ep_plugin_helpers/pad-toggle`.

## Dependencies

- `ep_plugin_helpers` ^0.3.0 (introduces `padToggle`).
- The pad-wide column requires the Etherpad core `ep_*` `padOptions` passthrough patch (ether/etherpad#7698, >= 2.7.4). On older cores the pad-wide checkbox is hidden automatically and the user-side cookie toggle keeps working — no breakage for un-patched cores.

## Test plan

- [ ] CI backend + frontend (Playwright) tests pass — existing `markdown.spec.ts` continues to click `#options-markdown` (same id; it is `options-` + settingId).
- [ ] Manual: toggle in User Settings flips markdown rendering on/off.
- [ ] Manual: toggle in Pad Wide Settings propagates to other connected clients.
- [ ] Manual: `enforceSettings` locks user-side checkbox to the pad-wide value.
- [ ] Manual: behaves gracefully on an Etherpad core without the padOptions passthrough patch (only User Settings toggle renders).

DO NOT MERGE until the etherpad-lite ether/etherpad#7698 padOptions passthrough is available in the core version targeted for the pad-wide column.